### PR TITLE
Fixed error when there is no summary in parsed feed

### DIFF
--- a/patreon-mp3.py
+++ b/patreon-mp3.py
@@ -61,7 +61,10 @@ f.entries.reverse()
 for item in f.entries:
   cnt += 1
   song = item.title
-  comment = item.summary.replace('<br>','').strip()
+  try:
+    comment = item.summary.replace('<br>','').strip()
+  except:
+    continue
   published = datetime.datetime(item.published_parsed[0]
     ,item.published_parsed[1]
     ,item.published_parsed[2]
@@ -114,7 +117,7 @@ for item in f.entries:
         t.images.set(3, coverImage, coverImageType)
         t.save(audioFileName, version=ID3_V2_4)
       # set the OS file time to the published time
-      os.utime(audioFileName, (datetime.mktime(published), datetime.mktime(published)))
+      os.utime(audioFileName, (time.mktime(published.timetuple()), time.mktime(published.timetuple())))
 
 # write out the newest item we saw, so we can skip previous
 # items on next run

--- a/patreon-mp3.py
+++ b/patreon-mp3.py
@@ -64,7 +64,7 @@ for item in f.entries:
   try:
     comment = item.summary.replace('<br>','').strip()
   except:
-    continue
+    pass
   published = datetime.datetime(item.published_parsed[0]
     ,item.published_parsed[1]
     ,item.published_parsed[2]


### PR DESCRIPTION
Script would die when no summary:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/feedparser/util.py", line 156, in __getattr__
    return self.__getitem__(key)
  File "/usr/local/lib/python3.10/dist-packages/feedparser/util.py", line 113, in __getitem__
    return dict.__getitem__(self, key)
KeyError: 'summary'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/justin/patreon-mp3-master/patreon-mp3.py", line 64, in <module>
    comment = item.summary.replace('<br>','').strip()
  File "/usr/local/lib/python3.10/dist-packages/feedparser/util.py", line 158, in __getattr__
    raise AttributeError("object has no attribute '%s'" % key)
AttributeError: object has no attribute 'summary'
```

fixed by putting a try around  ``` comment = item.summary.replace('<br>','').strip()```

then had issue where datetime.mktime is no longer a method, fixed by passing published as a struct_time to time.mktime