### PR TITLE
File name cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Uses a few Python libraries
 
 `pip3 install requests`
 
-## Eye3D
+## EyeD3
 
 [https://github.com/nicfit/eyeD3](https://github.com/nicfit/eyeD3)
 
-`pip3 install eye3d`
+`pip3 install eyed3`


### PR DESCRIPTION
Filename cleanup on download - remove all token characters after file extension.
Updated to remove depreciated utcfromtimestamp method.
Fixed spelling error in README.md